### PR TITLE
Esp32 v2.0.4 fixes

### DIFF
--- a/src/sfe_bus.cpp
+++ b/src/sfe_bus.cpp
@@ -251,7 +251,7 @@ bool SfeSPI::init(uint8_t cs,  bool bInit)
 {
 
 		//If the transaction settings are not provided by the user they are built here.
-		SPISettings spiSettings = SPISettings(3000000, LSBFIRST, SPI_MODE3); 
+		SPISettings spiSettings = SPISettings(3000000, MSBFIRST, SPI_MODE3); 
 
 		//In addition of the port is not provided by the user, it defaults to SPI here. 
 		return init(SPI, spiSettings, cs, bInit);

--- a/src/sfe_bus.cpp
+++ b/src/sfe_bus.cpp
@@ -346,7 +346,7 @@ int SfeSPI::readRegisterRegion(uint8_t addr, uint8_t reg, uint8_t *data, uint16_
     _spiPort->beginTransaction(_sfeSPISettings);
 		// Signal communication start
 		digitalWrite(_cs, LOW);
-		// A leading zero must be added to transfer with register to indicate a "read"
+		// A leading "1" must be added to transfer with register to indicate a "read"
 		reg = (reg | SPI_READ);
     _spiPort->transfer(reg);
 

--- a/src/sfe_ism330dhcx.cpp
+++ b/src/sfe_ism330dhcx.cpp
@@ -664,6 +664,7 @@ uint8_t QwDevISM330DHCX::getBlockDataUpdate()
 	uint8_t tempVal;
 	int32_t retVal = ism330dhcx_block_data_update_get(&sfe_dev, &tempVal);
 
+	(void)retVal;
 	return tempVal; 
 }
 
@@ -1346,14 +1347,7 @@ bool QwDevISM330DHCX::getExternalSensorNack(uint8_t sensor)
 
 bool QwDevISM330DHCX::readMMCMagnetometer(uint8_t* magData, uint8_t len)
 {
-	int32_t retVal;
-
-	readPeripheralSensor(magData, len); 
-
-	if( retVal != 0 )
-		return false;
-
-	return true;
+	return(readPeripheralSensor(magData, len));
 }
 
 
@@ -1399,10 +1393,9 @@ bool QwDevISM330DHCX::setHubWriteMode(uint8_t config)
 bool QwDevISM330DHCX::setHubPassThrough(bool enable)
 {
 
-	int32_t retVal;
-	ism330dhcx_sh_pass_through_set(&sfe_dev, (uint8_t)enable);
+	int32_t retVal = ism330dhcx_sh_pass_through_set(&sfe_dev, (uint8_t)enable);
 
-	if( retVal != 0 );
+	if( retVal != 0 )
 		return false;
 
 	return true; 


### PR DESCRIPTION
This PR:
* Includes changes to let the code compile cleanly on ESP32 v2.0.4
* Corrects the default bit ordering (MSBFIRST) for SPI
