### PR TITLE
Replace backslash in #include's

### DIFF
--- a/src/sfe_ism_shim.cpp
+++ b/src/sfe_ism_shim.cpp
@@ -1,6 +1,6 @@
 #include "sfe_ism_shim.h"
 #include "sfe_ism330dhcx.h"
-#include "st_src\ism330dhcx_reg.h"
+#include "st_src/ism330dhcx_reg.h"
 
 
 // Initializes the interfacing struct for STMicroelectronic's library. 

--- a/src/sfe_ism_shim.h
+++ b/src/sfe_ism_shim.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "st_src\ism330dhcx_reg.h"
+#include "st_src/ism330dhcx_reg.h"
 
 #ifdef __cpluplus
 extern "C"{


### PR DESCRIPTION
Backslash in include directives is undefined for many compilers. 
Let's use the standard!